### PR TITLE
Releasing animator listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Custom Dot progress bar.
 [![Release](https://jitpack.io/v/metagalactic/DotProgressBar.svg)](https://jitpack.io/#metagalactic/DotProgressBar)
 [![Platform](https://img.shields.io/badge/platform-android-green.svg)](http://developer.android.com/index.html)
 ![SDK](https://img.shields.io/badge/SDK-15%2B-green.svg)
-![Release](https://img.shields.io/badge/release-1.0.0-green.svg)
+![Release](https://img.shields.io/badge/release-1.0.3-green.svg)
 [![Build Status](https://travis-ci.org/metagalactic/DotProgressBar.svg?branch=master)](https://travis-ci.org/metagalactic/DotProgressBar)
 [![CircleCI](https://circleci.com/gh/metagalactic/DotProgressBar.svg?style=svg)](https://circleci.com/gh/metagalactic/DotProgressBar)
 

--- a/dotprogressbar/src/main/java/com/metagalactic/dotprogressbar/DotProgressBar.java
+++ b/dotprogressbar/src/main/java/com/metagalactic/dotprogressbar/DotProgressBar.java
@@ -73,7 +73,6 @@ public class DotProgressBar extends View {
         adjustDotBounds();
     }
 
-
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         float dotSize = mDotRadius * 2;

--- a/dotprogressbar/src/main/java/com/metagalactic/dotprogressbar/DotProgressBar.java
+++ b/dotprogressbar/src/main/java/com/metagalactic/dotprogressbar/DotProgressBar.java
@@ -24,7 +24,9 @@ public class DotProgressBar extends View {
     private static final int DEFAULT_ANIMATION_DURATION = 250;
     private static final float ANIMATION_DELAY_FACTOR = 0.3f;
     private List<Drawable> mDots;
+    private List<Animator> mAnimators;
     private AnimatorSet mAnimatorSet;
+    private ValueAnimator.AnimatorUpdateListener mAnimationListener;
 
     @ColorInt
     private int mDotColor;
@@ -63,9 +65,14 @@ public class DotProgressBar extends View {
         }
 
         mDots = new ArrayList<>(mNoOfDots);
-        setupDots();
+        for (int i = 0; i < mNoOfDots; i++) {
+            DotDrawable dotDrawable = new DotDrawable(mDotColor, mDotRadius);
+            dotDrawable.setCallback(this);
+            mDots.add(dotDrawable);
+        }
         adjustDotBounds();
     }
+
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
@@ -92,13 +99,13 @@ public class DotProgressBar extends View {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        mAnimatorSet.start();
+        createAnimation();
     }
 
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        mAnimatorSet.cancel();
+        tearDownAnimation();
     }
 
     @Override
@@ -125,40 +132,42 @@ public class DotProgressBar extends View {
         }
     }
 
-    private void setupDots() {
+    private void createAnimation() {
         mAnimatorSet = new AnimatorSet();
-        mDots.clear();
-
-        List<Animator> animators = new ArrayList<>(mNoOfDots);
+        mAnimators = new ArrayList<>(mNoOfDots);
+        mAnimationListener = new ValueAnimator.AnimatorUpdateListener() {
+            @Override
+            public void onAnimationUpdate(ValueAnimator animation) {
+                invalidate();
+            }
+        };
         float growRadius = mDotRadius * mGrowFactor;
-
         for (int i = 0; i < mNoOfDots; i++) {
-            DotDrawable dotDrawable = new DotDrawable(mDotColor, mDotRadius);
-            dotDrawable.setCallback(this);
-            mDots.add(dotDrawable);
-
-            ValueAnimator growAnimator = ObjectAnimator.ofFloat(dotDrawable,
+            ValueAnimator growAnimator = ObjectAnimator.ofFloat(mDots.get(i),
                     "radius", mDotRadius, growRadius, mDotRadius);
             growAnimator.setDuration(mAnimationDuration);
             growAnimator.setInterpolator(new AccelerateDecelerateInterpolator());
             growAnimator.setStartDelay((long) (i * mAnimationDuration * ANIMATION_DELAY_FACTOR));
             growAnimator.addUpdateListener(mAnimationListener);
-            animators.add(growAnimator);
+            mAnimators.add(growAnimator);
         }
-
-        mAnimatorSet.playTogether(animators);
+        mAnimatorSet.playTogether(mAnimators);
         mAnimatorSet.addListener(new AnimatorListenerAdapter() {
             @Override
             public void onAnimationEnd(Animator animation) {
                 mAnimatorSet.start();
             }
         });
+        mAnimatorSet.start();
     }
 
-    private ValueAnimator.AnimatorUpdateListener mAnimationListener = new ValueAnimator.AnimatorUpdateListener() {
-        @Override
-        public void onAnimationUpdate(ValueAnimator animation) {
-            invalidate();
+    private void tearDownAnimation() {
+        for (Animator animator : mAnimators) {
+            animator.removeAllListeners();
         }
-    };
+        mAnimators.clear();
+        mAnimatorSet.removeAllListeners();
+        mAnimatorSet.cancel();
+        mAnimationListener = null;
+    }
 }


### PR DESCRIPTION
Hi! I was running leak canary and noticed that mAnimationListener currently retains an instance of the view's context. This PR is to fix the leak. 
